### PR TITLE
Format README.md headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Javascript Feature Flags
 
 This Javascript function gets Feature Flags set in the URL (as fragment and/or query string), set in a browser cookie, and/or via matching a domain name (e.g., localhost, or your test domain name).
 
-##What are Feature Flags
+## What are Feature Flags
 
 A *Feature Flag* is a setting you use to turn a feature on or off. This is often used to turn on experimental features in your code, e.g., for testing.
 
-###Example
+## #Example
 
 ```html
 if ( ff.flag('crazy') ) {
@@ -17,7 +17,7 @@ if ( ff.flag('crazy') ) {
 }
 ```
 
-##And This Respository Is...
+## And This Respository Is...
 
 This is a Javascript function that reads feature flags in URL Fragments, query strings, browser cookies, and/or a test domain name. These are only "on" flags--they do not represent values or states beyond "on".
 
@@ -30,7 +30,7 @@ This function has no dependencies on other JS libaries, and should work on all m
 Note that this library doesn't help you set flags per se--it just reads them.
 
 
-##Basic Usage
+## Basic Usage
 
 ```html
 <script src="feature-flags.js"></script>
@@ -41,7 +41,7 @@ Note that this library doesn't help you set flags per se--it just reads them.
 </script>
 ```
 
-##Advanced Usage
+## Advanced Usage
 
 Take a look at the [feature-flags.js](feature-flags.js) file. This file can be integrated into your existing Javascript library, and you may change the global variable name (which is ff), or attach this function to an existing global, and override any of the following:
 
@@ -53,7 +53,7 @@ testDomainFlag: 'debug',
 methods: ['cookie', 'domain', 'hash', 'query'])
 ```
 
-##Flag Syntax
+## Flag Syntax
 
 This function recognizes as flags parameters that use a consistent "key" name format. The **keyName** defaults to **ff**, but you can easily change this via the  [Advance Usage](#advanced-usage) options.
 
@@ -61,7 +61,7 @@ Note that comma separated values are always turned into separate flags.
 
 Syntax examples (todo: document a bit more)
 
-###Query Strings
+### Query Strings
 
 All valid:
 
@@ -72,7 +72,7 @@ All valid:
 ?ff=Jimi,Eddie&ff=George,Sonny
 ````
 
-###Fragments
+### Fragments
 
 All valid:
 
@@ -81,12 +81,12 @@ All valid:
 #ff,Elvin,Ringo
 ````
 
-###Cookies
+### Cookies
 
 The function will set flags based on a cookie set with the keyName (e.g., **ff**). The cookie may contain either a single value, or multiple comma separated values.
 
 
-###Test Domain
+### Test Domain
 
 By default, if the page is being browsed on localhost, a flag named debug will be set. Via the [Advance Usage](#advanced-usage) examples above, you can change this to match your test domain name, and change the flag that is set.
 
@@ -95,7 +95,7 @@ By default, if the page is being browsed on localhost, a flag named debug will b
 
 See the [index.html](http://jayf.github.io/javascript-feature-flags/index.html) page for more examples.
 
-##Enhancements
+## Enhancements
 
 Some ideas are in [issues/enhancements](https://github.com/jayf/javascript-feature-flags/issues?labels=enhancement&page=1&state=open) -- feel free to add suggestions, or fork and submit your own.
 


### PR DESCRIPTION
Headers require a space after the `#` in order to display properly as markdown headers.